### PR TITLE
Bump dependencies for Laravel 9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "doctrine/dbal": "~2.3",
+        "php": "^7.1|^8.0",
+        "doctrine/dbal": "~2.3|^3.3",
         "phpdocumentor/graphviz": "^1.0",
-        "nikic/php-parser":"^2.0|^3.0|^4.0"
+        "nikic/php-parser": "^2.0|^3.0|^4.0"
     },
     "require-dev": {
         "larapack/dd": "^1.0",
-        "orchestra/testbench": "~3.5|~3.6|~3.7|~3.8|^4.0",
-        "phpunit/phpunit": "^7.0| ^8.0",
-        "spatie/phpunit-snapshot-assertions": "^1.3"
+        "orchestra/testbench": "~3.5|~3.6|~3.7|~3.8|^4.0|^7.0",
+        "phpunit/phpunit": "^7.0| ^8.0|^9.5.10",
+        "spatie/phpunit-snapshot-assertions": "^1.3|^4.2"
     },
     "autoload": {
         "psr-4": {
@@ -40,7 +40,6 @@
     "scripts": {
         "test": "vendor/bin/phpunit",
         "test-coverage": "vendor/bin/phpunit --coverage-html coverage"
-
     },
     "config": {
         "sort-packages": true


### PR DESCRIPTION
This is the pull request from laravel shift that updates the package to work with Laravel 9. Unfortunately, it doesn't look like the original package is being maintained.